### PR TITLE
Removes the is major = yes check for the special forces button

### DIFF
--- a/common/decisions/_generic_decisions.txt
+++ b/common/decisions/_generic_decisions.txt
@@ -1933,7 +1933,6 @@ war_measures = {
 
 		visible = {
 			AND = {
-				is_major = yes
 				has_dlc = "Arms Against Tyranny"
 				NOT = {
 					OR = {


### PR DESCRIPTION
Exactly as it says on the tin. It's silly that you have to be a major country (that is, gold-bordered on the war screen) to access this button.
Other options are to go through and remove the effect from focuses that grant the extra special forces slot to the specific countries excluded by this decision, but that takes more effort than I'm willing to countenance right now.