### PR TITLE
Adds a decision for FRA to request the Franco-British Union

### DIFF
--- a/common/decisions/JAP.txt
+++ b/common/decisions/JAP.txt
@@ -989,41 +989,7 @@ JAP_southern_expansion = {
 					}
 				} 
 			}
-			custom_trigger_tooltip = {
-				tooltip = demand_indochina_focus_tt
-				OR = {
-					286 = { 
-						CONTROLLER = { 
-							OR = { 
-								tag = FRA 
-								tag = VIC
-								is_subject_of = FRA
-								is_subject_of = VIC 
-							} 
-						}
-					}
-					670 = { 
-						CONTROLLER = { 
-							OR = { 
-								tag = FRA 
-								tag = VIC 
-								is_subject_of = FRA
-								is_subject_of = VIC
-							} 
-						}
-					}
-					671 = { 
-						CONTROLLER = { 
-							OR = { 
-								tag = FRA 
-								tag = VIC 
-								is_subject_of = FRA
-								is_subject_of = VIC
-							} 
-						}
-					}
-				}
-			}
+			
 		}
 
 		visible = {
@@ -1074,18 +1040,18 @@ JAP_southern_expansion = {
 			}
 			else_if = {
 				limit = {
-					VIC = {
+					ENG = {
 						OR = {
 							controls_state = 671
 							controls_state = 670
 							controls_state = 286
-							671 = { CONTROLLER = { is_subject_of = VIC } }
-							670 = { CONTROLLER = { is_subject_of = VIC } }
-							286 = { CONTROLLER = { is_subject_of = VIC } }
+							671 = { CONTROLLER = { is_subject_of = ENG } }
+							670 = { CONTROLLER = { is_subject_of = ENG } }
+							286 = { CONTROLLER = { is_subject_of = ENG } }
 						}
 					}
 				}
-				VIC = { country_event = { id = france.1 } }
+				ENG = { country_event = { id = france.1 } }
 			}
 		}
 

--- a/common/decisions/amsb.txt
+++ b/common/decisions/amsb.txt
@@ -2,7 +2,6 @@ war_measures = {		#Name of category that decisions will appear under, decisions 
 	###############################################
 	#### DECISIONS WITH TIMERS BECOME MISSIONS ####
 	###############################################
-	
 
 	retake_UK = {		#ID of the mission, must not contain spaces!
 
@@ -60,8 +59,23 @@ war_measures = {		#Name of category that decisions will appear under, decisions 
 		}
 	}
 }
+political_actions = {
+	propose_franco_british_union = {
+		allowed = {tag = FRA}
+		available = { 
+			tag = FRA
+			FRA = {has_capitulated = yes}
+			EFR = {controls_province = 3594} #just to make sure you don't click it before Vichy spawns in, causes surrender limit issues with ENG
+		}
+		complete_effect = {
+			ENG = { 
+				country_event = fruk.11
+			}
+		}
+	}
+}
 SOV_great_patriotic_war = {
-	SOV_dynamite_the_dnieper_dam = { 
+	SOV_dynamite_the_dnieper_dam = {  #the very symbol of the five-year plan!
 		icon = GFX_decision_hol_inundate_water_lines
 		
 		allowed = {

--- a/common/decisions/amsb.txt
+++ b/common/decisions/amsb.txt
@@ -66,6 +66,7 @@ political_actions = {
 			tag = FRA
 			FRA = {has_capitulated = yes}
 			EFR = {controls_province = 3594} #just to make sure you don't click it before Vichy spawns in, causes surrender limit issues with ENG
+			 date < 1941.1.1
 		}
 		complete_effect = {
 			ENG = { 

--- a/events/Japan.txt
+++ b/events/Japan.txt
@@ -276,6 +276,7 @@ country_event = {
 								original_tag = FRA
 								is_subject_of = FRA
 								is_subject_of = VIC
+								original_tag = ENG
 							}
 						}
 					}
@@ -290,6 +291,7 @@ country_event = {
 								original_tag = FRA
 								is_subject_of = FRA
 								is_subject_of = VIC
+								original_tag = ENG
 							}
 						}
 					}
@@ -304,6 +306,7 @@ country_event = {
 								original_tag = FRA
 								is_subject_of = FRA
 								is_subject_of = VIC
+								original_tag = ENG
 							}
 						}
 					}
@@ -318,6 +321,7 @@ country_event = {
 								original_tag = FRA
 								is_subject_of = FRA
 								is_subject_of = VIC
+								original_tag = ENG
 							}
 						}
 					}
@@ -332,6 +336,7 @@ country_event = {
 								original_tag = FRA
 								is_subject_of = FRA
 								is_subject_of = VIC
+								original_tag = ENG
 							}
 						}
 					}

--- a/events/amsb.txt
+++ b/events/amsb.txt
@@ -1,4 +1,5 @@
 # SEALION (Germany)
+add_namespace = fruk
 add_namespace = sealion
 add_namespace = dnieper
 add_namespace = uktanks
@@ -147,6 +148,128 @@ news_event = {
 				TAG = USA
 				NOT = {is_in_faction_with = ENG}
 			}
+		}
+	}
+}
+## France moves to UK coop
+country_event = {
+	id = fruk.11
+	title = france.11.t
+	desc = france.11.d
+	picture = GFX_report_event_degaulle_churchill
+	
+	is_triggered_only = yes
+	
+	option = { # Refuse Union
+		name = france.11.a
+		ai_chance = {
+			factor = 10
+		}
+		FRA = {
+			country_event = { hours = 6 id = france.13 }
+		}
+	}
+	option = { # Agree to Union
+		name = france.11.b
+		ai_chance = {
+			factor = 90
+		}
+		FRA = {
+			country_event = { hours = 6 id = fruk.12 }
+		}
+	}
+}
+country_event = {
+		id = fruk.12
+		title = france.12.t
+		desc = france.12.d
+		picture = GFX_report_event_chamberlain_announce
+		
+		is_triggered_only = yes
+		set_global_flag = flag_franco_british_union
+		option = {
+			name = france.12.a
+			# Franco-British Union created
+			hidden_effect = {
+				every_state = {
+					limit = {
+						is_core_of = FRA
+					}
+					ENG = {
+						add_state_core = PREV
+					}
+				}
+			}
+		FRA = {
+			every_unit_leader = {
+				set_unit_leader_flag = flag_former_french_general
+				set_nationality = ENG
+			}
+		}
+		ENG = {
+			annex_country = { target = FRA transfer_troops = yes }
+		}
+		custom_effect_tooltip = FRA_franco_british_cores
+		hidden_effect = {
+			ENG = { 
+				set_cosmetic_tag = FRA_UK 
+				country_event = { hours = 12 id = fruk.35 }
+			}
+		}
+		}
+	}
+	
+news_event = {
+	id = fruk.35
+	title = news.35.t
+	desc = news.35.d
+	picture = GFX_news_event_churchill_degaulle
+	
+	major = yes
+	
+	is_triggered_only = yes
+	
+	option = {
+		name = news.35.a
+		trigger = {
+			NOT = { TAG = GER	}
+			NOT = { TAG = ENG	}
+			NOT = { is_in_faction_with = GER }
+			NOT = { is_in_faction_with = ENG }
+		}
+	}
+	option = {
+		name = news.35.b
+		trigger = {
+			OR = {
+				is_in_faction_with = GER
+				TAG = GER 
+			}
+		}
+	}
+	option = {
+		name = news.35.c
+		trigger = {
+				TAG = ENG
+		}
+		hidden_effect = {
+			every_owned_state = {
+				limit = {
+					not = { is_core_of = ROOT }
+					not = { is_on_continent = europe }
+				}
+				add_compliance = 50
+			}
+		}
+	}
+	option = {
+		name = news.35.c
+		trigger = {
+			AND = {
+				is_in_faction_with = ENG
+				NOT = {TAG = ENG}
+			}
+		}
 		}
 	}
 }

--- a/localisation/english/amsb_l_english.yml
+++ b/localisation/english/amsb_l_english.yml
@@ -23,6 +23,8 @@
   dnieper.1.e:0 "Hoover and Wilson stand alone once more."
   dnieper.1.f:0 "The Russians demonstrate their resolve."
   dnieper_river_blown:0 "Dnieper Flooding"
+  propose_franco_british_union:0 "Propose Franco-British Union"
+  propose_franco_british_union_desc:0 "This decision is give the FRA player a chance to have game-impact as the UK coop after they capitulate, if they like. You will be annexed to ENG and will (probably) have to rejoin."
   seize_egypt:0 "Seize Egyptian Gold Reserves"
   seize_france:0 "Seize French Gold Reserves"
   seize_poland:0 "Seize Polish Gold Reserves"

--- a/localisation/english/amsb_l_english.yml
+++ b/localisation/english/amsb_l_english.yml
@@ -23,7 +23,7 @@
   dnieper.1.e:0 "Hoover and Wilson stand alone once more."
   dnieper.1.f:0 "The Russians demonstrate their resolve."
   dnieper_river_blown:0 "Dnieper Flooding"
-  propose_franco_british_union:0 "Propose Franco-British Union"
+  propose_franco_british_union:0 "Propose Franco-British Union (YOU WILL BE ANNEXED TO UK)"
   propose_franco_british_union_desc:0 "This decision is give the FRA player a chance to have game-impact as the UK coop after they capitulate, if they like. You will be annexed to ENG and will (probably) have to rejoin."
   seize_egypt:0 "Seize Egyptian Gold Reserves"
   seize_france:0 "Seize French Gold Reserves"


### PR DESCRIPTION
Adds a decision for FRA after Vichy spawns in to request the Franco-British Union, which
- gives the UK cores on all French cores
- annexes FRA
- adds compliance in the FRA colonies to make up for the transfer-loss of compliance (adds 50 compliance, which should counteract the -50% you get from switching to UK ownership at full compliance)
It should work with the JAP decision to steal indochina (it does, I've tested it)
