### PR TITLE
Fixes the Raj tree and Romania tree war eco focuses

### DIFF
--- a/common/national_focus/india_goe.txt
+++ b/common/national_focus/india_goe.txt
@@ -15323,7 +15323,12 @@ focus_tree = {
         completion_reward = {
             if = {
                 limit = {
-                    NOT = { has_idea = war_economy }
+                    NOT = { 
+						OR = {
+							has_idea = tot_economic_mobilisation 
+							has_idea = war_economy 
+						}
+					}
                 }
                 add_ideas = war_economy
             }

--- a/common/national_focus/romania.txt
+++ b/common/national_focus/romania.txt
@@ -392,8 +392,14 @@ focus_tree = {
 		}
 		search_filters = { FOCUS_FILTER_INDUSTRY }
 		completion_reward = {
-		if = { limit = { has_idea = war_economy }
-			add_political_power = 150
+		if = { 
+			limit = {
+				OR = {
+					has_idea = war_economy
+					has_idea = tot_economic_mobilisation
+				}
+			}
+		add_political_power = 150
 		}
 		else = {
 			add_ideas = war_economy


### PR DESCRIPTION
Previously both ROM and RAJ would go back to war eco from total mob if they completed the relevant war-eco focus. Changed it so if they are already on total mobilisation, the focus does the same thing it would do if you were already on war eco:

Romania: +150 pp
Raj: No reward (previously was -10 resistance and flips you to war eco regardless, now it just gives you -10 everywhere).
 
I think you do actually get war eco via the Raj focus, mostly, so it's not really a big issue that there's not a +150pp reward for Raj. Also, there isn't one in vanilla so I decided to not change it. 