### PR TITLE
Romania fixes for AI-controlled, changed Derna oilfield decision category to reduce bloat

### DIFF
--- a/common/decisions/ROM.txt
+++ b/common/decisions/ROM.txt
@@ -31,6 +31,58 @@ ROM_oil_production = {
             }
 		}
 	}
+	develop_derna_oilfield = { #76
+
+		icon = oil
+
+		allowed = {
+
+		}
+		highlight_states = {
+			highlight_state_targets = {
+				state = 76
+			}
+		}
+		available = {
+			has_tech = excavation4
+			num_of_civilian_factories_available_for_projects > 14
+			owns_state = 76
+			controls_state = 76
+		}
+
+		visible = {
+			owns_state = 76
+			controls_state = 76
+			76 = {
+				NOT = {
+					has_state_flag = derna_oil_developed
+				}
+			}
+		}
+
+		fire_only_once = yes
+
+		cost = 50
+		days_remove = 60
+
+		modifier = {
+			civilian_factory_use = 15
+		}
+
+		ai_will_do = {
+			base = 0 #Not historically excavated
+		}
+
+		remove_effect = {
+			76 = { set_state_flag = derna_oil_developed }
+			76 = {
+				add_resource = {
+					type = oil
+					amount = 24
+				}
+			}
+		}
+	}
 	ROM_is_ai = {
 		icon = oil
 		allowed = {	

--- a/common/decisions/ROM.txt
+++ b/common/decisions/ROM.txt
@@ -34,13 +34,11 @@ ROM_oil_production = {
 	ROM_is_ai = {
 		icon = oil
 		allowed = {	
-			original_tag = ROM
-			ROM = {is_ai = yes}	
+				original_tag = ROM
+				ROM = {is_ai = yes}
 		}
-		available = {
-			tag = ROM
-			ROM = {is_ai = yes}
-		}
+		visible = {is_ai = yes}
+		available = {is_ai = yes}
 		cost = 0
 		fire_only_once = yes
 		complete_effect = {
@@ -48,8 +46,7 @@ ROM_oil_production = {
         }
 		ai_will_do = {
 			base = 4000
-			}	
-		}
+		}	
 	}
 }
 

--- a/common/decisions/ROM.txt
+++ b/common/decisions/ROM.txt
@@ -30,6 +30,26 @@ ROM_oil_production = {
                 }
             }
 		}
-	}	
-
+	}
+	ROM_is_ai = {
+		icon = oil
+		allowed = {	
+			original_tag = ROM
+			ROM = {is_ai = yes}	
+		}
+		available = {
+			tag = ROM
+			ROM = {is_ai = yes}
+		}
+		cost = 0
+		fire_only_once = yes
+		complete_effect = {
+			add_ideas = free_trade
+        }
+		ai_will_do = {
+			base = 4000
+			}	
+		}
+	}
 }
+

--- a/history/countries/ROM - Romania.txt
+++ b/history/countries/ROM - Romania.txt
@@ -152,9 +152,7 @@ add_ideas = ROM_waning_influence_of_democracy
 add_ideas = ROM_romanian_officers
 add_ideas = ROM_iron_guard
 add_ideas = ROM_king_carol_ii_hedonist
-if = {
-	limit = {is_ai = no}
-	add_ideas = ROM_oil_lend_lease}
+add_ideas = ROM_oil_lend_lease
 
 set_convoys = 60
 


### PR DESCRIPTION
If ROM is AI, it will do a decision to switch to free trade, which the player cannot choose. Regular start is unchanged.