### PR TITLE
Adds in the ElectionEvents.txt to remove the stupid "public opposes rearmament" or "demands rearmament" events

### DIFF
--- a/events/ElectionEvents.txt
+++ b/events/ElectionEvents.txt
@@ -1,0 +1,810 @@
+﻿###########################
+# Election Events
+###########################
+
+add_namespace = election
+
+# Test Election Event
+country_event = {
+	id = election.1
+	title = election.1.t
+	desc = election.1.d
+	picture = GFX_report_event_election_vote
+	
+	is_triggered_only = yes
+	
+	option = {
+		name = election.1.a
+	}
+}
+
+# Fascists in Government?
+country_event = {
+	id = election.4
+	title = election.4.t
+	desc = election.4.d
+	picture = GFX_report_event_fascist_gathering
+	
+	is_triggered_only = yes
+
+	trigger = {
+		NOT = { 
+			AND = { 
+				tag = USA 
+				date < 1949.1.1
+			} 
+			AND = { 
+				tag = GRE 
+				#has_dlc = "Battle for the Bosporus"
+			} 
+			AND = {
+				has_dlc = "Trial of Allegiance"
+				tag = BRA
+			}
+		}
+		DEN_aat = no #Denmark has custom election events
+		NOR_AAT = no
+		OR = { NOT = { original_tag = SPR } NOT = { date < 1937.1.1 } }
+		has_government = democratic
+		NOT = { has_idea = fascism_defeated }
+		fascism > 0.15
+	}
+	
+	option = {
+		name = election.4.a
+		ai_chance = {
+			base = 0
+			modifier = {
+				add = 2
+				can_lose_democracy_support = yes
+			}
+			modifier = {
+				add = 1
+				can_lose_unity = no
+			}
+		}
+		add_popularity = {
+			ideology = fascism
+			popularity = 0.1
+		}
+		set_country_flag = coalition_with_fascists
+	}
+
+	option = {
+		name = election.4.b
+		ai_chance = {
+			base = 0
+			modifier = {
+				add = 10
+				can_lose_unity = yes
+			}
+		}
+		add_stability = -0.05
+		add_popularity = {
+			ideology = democratic
+			popularity = 0.03
+		}
+		set_country_flag = government_declined_fascists
+	}
+}
+
+# Communists in Government?
+country_event = {
+	id = election.5
+	title = election.5.t
+	desc = election.5.d
+	picture = GFX_report_event_worker_protests
+	
+	is_triggered_only = yes
+
+	trigger = {
+		NOT = { 
+			AND = { 
+				tag = USA 
+				date < 1949.1.1
+			} 
+			AND = { 
+				tag = GRE 
+				#has_dlc = "Battle for the Bosporus"
+			} 
+			AND = { 
+				tag = CHL 
+				has_dlc = "Trial of Allegiance"
+			} 
+			AND = {
+				has_dlc = "Trial of Allegiance"
+				tag = BRA
+			}
+		}
+		DEN_aat = no #Denmark has custom election events
+		NOR_AAT = no
+		OR = { NOT = { original_tag = SPR } NOT = { date < 1937.1.1 } }
+		has_government = democratic
+		NOT = { has_idea = communism_defeated }
+		communism > 0.15
+	}
+	
+	option = {
+		name = election.5.a
+		ai_chance = {
+			base = 0
+			modifier = {
+				add = 2
+				can_lose_democracy_support = yes
+			}
+			modifier = {
+				add = 1
+				can_lose_unity = no
+			}
+			modifier = {
+				factor = 0
+				OR = {
+					AND = {
+						tag = FRA
+						is_historical_focus_on = yes
+						date < 1937.1.1
+					}
+					communism > 0.38
+				}
+			}
+		}
+		add_popularity = {
+			ideology = communism
+			popularity = 0.1
+		}
+		set_country_flag = coalition_with_communists
+	}
+
+	option = {
+		name = election.5.b
+		ai_chance = {
+			base = 0
+			modifier = {
+				add = 10
+				can_lose_unity = yes
+			}
+			modifier = {
+				add = 1
+				OR = {
+					AND = {
+						tag = FRA
+						is_historical_focus_on = yes
+						date < 1937.1.1
+					}
+					communism > 0.38
+				}
+			}
+		}
+		add_stability = -0.05
+		add_popularity = {
+			ideology = democratic
+			popularity = 0.03
+		}
+		set_country_flag = government_declined_communists
+	}
+}
+
+# Democratic Parties in Minority
+country_event = {
+	id = election.6
+	title = election.6.t
+	desc = election.6.d
+	picture = GFX_report_event_journalists_speech
+	
+	is_triggered_only = yes
+
+	trigger = {
+		NOT = { 
+			AND = { 
+				tag = USA 
+				date < 1949.1.1
+			}
+			AND = {
+				NOR_AAT = yes
+				date < 1949.1.1
+			} 
+			AND = { 
+				tag = GRE 
+				#has_dlc = "Battle for the Bosporus"
+			} 
+			AND = {
+				has_dlc = "Trial of Allegiance"
+				tag = BRA
+			}
+		}
+		DEN_aat = no #Denmark has custom election events
+		NOR_aat = no
+		OR = { NOT = { original_tag = SPR } NOT = { date < 1937.1.1 } }
+		has_government = democratic
+		democratic < 0.5
+		fascism < 0.5
+		communism < 0.5
+	}
+	
+	option = {
+		name = election.6.a
+		ai_chance = {
+			base = 0
+			modifier = {
+				add = 10
+				can_lose_democracy_support = yes
+			}
+		}
+		trigger = {
+			NOT = {
+				AND = {
+					has_dlc = "Arms Against Tyranny"
+					tag = DEN
+					is_subject = yes
+					var:DEN.DEN_overlord_nation = { has_government = communism }
+				}
+			}
+		}
+		add_popularity = {
+			ideology = fascism
+			popularity = 0.1
+		}
+		set_country_flag = coalition_with_fascists
+	}
+
+	option = {
+		name = election.6.b
+		ai_chance = {
+			base = 0
+			modifier = {
+				add = 10
+				can_lose_democracy_support = yes
+			}
+		}
+		trigger = {
+			NOT = {
+				AND = {
+					has_dlc = "Arms Against Tyranny"
+					tag = DEN
+					is_subject = yes
+					var:DEN.DEN_overlord_nation = { has_government = fascism }
+				}
+			}
+		}
+		add_popularity = {
+			ideology = communism
+			popularity = 0.1
+		}
+		set_country_flag = coalition_with_communists
+	}
+
+	option = {
+		name = election.6.c
+		ai_chance = {
+			base = 0
+			modifier = {
+				add = 1
+				can_lose_democracy_support = no
+			}
+		}
+		add_popularity = {
+			ideology = democratic
+			popularity = 0.05
+		}
+		add_political_power = -80
+	}
+}
+
+# Fascists Influence Foreign Policy
+country_event = {
+	id = election.7
+	title = election.7.t
+	desc = election.7.d
+	picture = GFX_report_event_fascist_gathering
+	
+	mean_time_to_happen = {
+		days = 730
+	}
+
+	trigger = {
+		NOT = { 
+			AND = { 
+				tag = USA 
+				date < 1949.1.1
+			} 
+			AND = { 
+				tag = GRE 
+				#has_dlc = "Battle for the Bosporus"
+			} 
+			AND = {
+				has_dlc = "Trial of Allegiance"
+				tag = BRA
+			}
+		}
+		DEN_aat = no #Denmark has custom election events
+		NOR_aat = no 
+		OR = { NOT = { original_tag = SPR } NOT = { date < 1937.1.1 } }
+		has_government = democratic
+		has_country_flag = coalition_with_fascists
+		any_other_country = {
+			has_government = fascism
+			is_faction_leader = yes
+		}
+	}
+	
+	option = {
+		name = election.7.a
+		ai_chance = {
+			base = 0
+			modifier = {
+				add = 2
+				can_lose_democracy_support = yes
+			}
+			modifier = {
+				add = 1
+				can_lose_unity = no
+			}
+		}
+		random_other_country = {
+			limit = {
+				has_government = fascism
+				is_faction_leader = yes
+			}
+			add_opinion_modifier = {
+				target = ROOT
+				modifier = fascists_in_government
+			}			
+		}
+		add_popularity = {
+			ideology = fascism
+			popularity = 0.05
+		}
+	}
+
+	option = {
+		name = election.7.b
+		ai_chance = {
+			base = 10
+			modifier = {
+				factor = 0
+				can_lose_unity = no
+			}
+		}
+		add_stability = -0.05
+		add_popularity = {
+			ideology = democratic
+			popularity = 0.03
+		}
+	}
+}
+
+# Communists Influence Foreign Policy
+country_event = {
+	id = election.8
+	title = election.8.t
+	desc = election.8.d
+	picture = GFX_report_event_worker_protests
+	
+	mean_time_to_happen = {
+		days = 730
+	}
+
+	trigger = {
+		NOT = { 
+			AND = { 
+				tag = USA 
+				date < 1949.1.1
+			} 
+			AND = { 
+				tag = GRE 
+				#has_dlc = "Battle for the Bosporus"
+			} 
+			AND = {
+				has_dlc = "Trial of Allegiance"
+				tag = BRA
+			}
+		}
+		DEN_aat = no #Denmark has custom election events
+		NOR_aat = no 
+		OR = { NOT = { original_tag = SPR } NOT = { date < 1937.1.1 } }
+		has_government = democratic
+		has_country_flag = coalition_with_communists
+		any_other_country = {
+			has_government = communism
+			is_faction_leader = yes
+		}
+	}
+	
+	option = {
+		name = election.8.a
+		ai_chance = {
+			base = 0
+			modifier = {
+				add = 2
+				can_lose_democracy_support = yes
+			}
+			modifier = {
+				add = 1
+				can_lose_unity = no
+			}
+		}
+		random_other_country = {
+			limit = {
+				has_government = communism
+				is_faction_leader = yes
+				NOT = { has_war_with = ROOT }
+			}
+			add_opinion_modifier = {
+				target = ROOT
+				modifier = communists_in_government
+			}
+		}
+		add_popularity = {
+			ideology = communism
+			popularity = 0.05
+		}
+	}
+
+	option = {
+		name = election.8.b
+		ai_chance = {
+			base = 10
+			modifier = {
+				factor = 0
+				can_lose_unity = no
+			}
+		}
+		add_stability = -0.05
+		add_popularity = {
+			ideology = democratic
+			popularity = 0.03
+		}
+	}
+}
+
+# Fascist Majority
+country_event = {
+	id = election.11
+	title = election.11.t
+	desc = election.11.d
+	picture = GFX_report_event_fascist_gathering
+	
+	is_triggered_only = yes
+
+	trigger = {
+		has_government = democratic
+		fascism > 0.5
+		is_puppet = no
+		DEN_aat = no #Denmark has custom election events
+		NOR_AAT = no 
+		NOT = {
+			AND = {
+				original_tag = SPR
+				has_dlc = "La Resistance"
+			}
+			AND = {
+				original_tag = GRE
+				has_dlc = "Battle for the Bosporus"
+			}
+			AND = {
+				original_tag = TUR
+				has_dlc = "Battle for the Bosporus"
+			}
+			AND = {
+				original_tag = SWI
+				has_dlc = "By Blood Alone"
+			}
+			AND = {
+				has_dlc = "Trial of Allegiance"
+				tag = BRA
+			}
+		}
+	}
+	
+	option = {	
+		name = election.11.a
+		ai_chance = {
+			base = 75			
+		}
+		set_politics = {
+			ruling_party = fascism
+			elections_allowed = no
+		}
+	}
+
+	option = {
+		name = election.11.b
+		ai_chance = {
+			base = 35
+		}
+		start_civil_war = {
+			ideology = fascism
+			size = 0.5
+		}
+	}
+}
+
+# Communist Majority
+country_event = {
+	id = election.12
+	title = election.12.t
+	desc = election.12.d
+	picture = GFX_report_event_gathering_protest
+	
+	is_triggered_only = yes
+
+	trigger = {
+
+		has_government = democratic
+		communism > 0.5
+		is_puppet = no
+		DEN_aat = no #Denmark has custom election events
+		NOR_AAT = no 
+		NOT = {
+			AND = {
+				original_tag = GRE
+				has_dlc = "Battle for the Bosporus"
+			}
+			AND = {
+				original_tag = TUR
+				has_dlc = "Battle for the Bosporus"
+			}
+			AND = {
+				has_dlc = "Trial of Allegiance"
+				tag = BRA
+			}
+		}
+	}
+	
+	option = {
+		name = election.12.a
+		ai_chance = {
+			base = 75
+		}
+		set_politics = {
+			ruling_party = communism
+			elections_allowed = no
+		}
+	}
+
+	option = {
+		name = election.12.b
+		ai_chance = {
+			base = 35			
+		}
+		start_civil_war = {
+			ideology = communism
+			size = 0.5
+		}
+	}
+}
+
+# Magnate Favors Fascism
+country_event = {
+	id = election.13
+	title = election.13.t
+	desc = election.13.d
+	picture = GFX_report_event_fascist_gathering
+	
+	is_triggered_only = yes
+
+	trigger = {
+		NOT = { 
+			AND = {
+				Tag = USA
+				date < 1949.1.1
+			}
+		}
+		DEN_aat = no #Denmark has custom election events
+		has_government = democratic
+		has_idea_with_trait = motorized_equipment_manufacturer
+	}
+	
+	option = {
+		name = election.13.a
+		ai_chance = {
+			base = 0
+			modifier = {
+				add = 1
+				can_lose_democracy_support = yes
+			}
+		}
+		add_popularity = {
+			ideology = fascism
+			popularity = 0.10
+		}
+	}
+
+	option = {
+		name = election.13.b
+		ai_chance = {
+			base = 0
+			modifier = {
+				add = 1
+				can_lose_democracy_support = no
+			}
+		}
+		add_popularity = {
+			ideology = democratic
+			popularity = 0.05
+		}
+		remove_ideas_with_trait = motorized_equipment_manufacturer
+	}
+}
+
+# Wartime Exception
+country_event = {
+	id = election.14
+	title = election.14.t
+	desc = election.14.d
+	picture = GFX_report_event_tank_factory
+	
+	is_triggered_only = yes
+
+	trigger = {
+		NOT = { 
+			AND = { 
+				tag = USA 
+				date < 1949.1.1
+			} 
+		}
+		OR = { NOT = { original_tag = SPR } NOT = { date < 1937.1.1 } }
+		has_government = democratic
+		has_war = yes
+	}
+	
+	option = {
+		name = election.14.a
+		ai_chance = {
+			base = 0
+			modifier = {
+				add = 10
+				can_lose_unity = yes
+			}
+		}
+		add_stability = -0.05
+		if =  {
+			limit = {
+				original_tag = DEN
+				has_dlc = "Arms Against Tyranny"
+			}
+			clr_country_flag = DEN_at_war_flag #This is done to be able to trigger the following event:
+			country_event = { id = denmark_political_events.3 }
+		}
+	}
+
+	option = {
+		ai_chance = {
+			base = 0
+			modifier = {
+				add = 3
+				can_lose_democracy_support = yes
+			}			
+			modifier = {
+				add = 1
+				can_lose_unity = no
+			}
+		}
+		name = election.14.b
+		add_political_power = 20
+		add_stability = 0.05
+		add_popularity = {
+			ideology = communism
+			popularity = 0.05
+		}
+		add_popularity = {
+			ideology = fascism
+			popularity = 0.05
+		}
+	}
+}
+
+# Government Contested
+country_event = {
+	id = election.15
+	title = election.15.t
+	desc = election.15.d
+	picture = GFX_report_event_gathering_protest
+	
+	is_triggered_only = yes
+
+	trigger = {
+		NOT = { 
+			AND = { 
+				tag = USA 
+				date < 1949.1.1
+			} 
+		}
+		OR = { NOT = { original_tag = SPR } NOT = { date < 1937.1.1 } }
+		has_government = democratic
+		has_war = yes
+		any_war_score < 20
+	}
+	
+	option = {
+		ai_chance = {
+			base = 0
+			modifier = {
+				add = 3
+				can_lose_democracy_support = no
+			}			
+		}
+		name = election.15.a
+		add_political_power = -50
+		add_stability = -0.05
+	}
+
+	option = {
+		name = election.15.b
+		ai_chance = {
+			base = 0
+			modifier = {
+				add = 10
+				can_lose_democracy_support = yes
+			}			
+			modifier = {
+				add = 1
+				can_lose_unity = no
+			}
+		}
+		add_political_power = 25
+		add_stability = 0.05
+		add_popularity = {
+			ideology = communism
+			popularity = 0.07
+		}
+		add_popularity = {
+			ideology = fascism
+			popularity = 0.07
+		}
+	}
+}
+
+# Election in Fascist Country (Supports Government)
+country_event = {
+	id = election.16
+	title = election.16.t
+	desc = election.16.d
+	picture = GFX_report_event_gathering_protest
+	
+	is_triggered_only = yes
+
+	trigger = {
+		NOT = { 
+			AND = { 
+				tag = USA 
+				date < 1949.1.1
+			} 
+		}
+		OR = { NOT = { original_tag = SPR } NOT = { date < 1937.1.1 } }
+		has_government = fascism
+		fascism > 0.5
+	}
+	
+	option = {
+		name = election.16.a
+		add_stability = 0.05
+	}
+}
+
+# Rigged Election in Fascist Country
+country_event = {
+	id = election.17
+	title = election.17.t
+	desc = election.17.d
+	picture = GFX_report_event_gathering_protest
+	
+	is_triggered_only = yes
+
+	trigger = {
+		NOT = { 
+			AND = { 
+				tag = USA 
+				date < 1949.1.1
+			}
+		}
+		OR = { NOT = { original_tag = SPR } NOT = { date < 1937.1.1 } }
+		has_government = fascism
+		NOT = { fascism > 0.5 }
+	}
+	
+	option = {
+		name = election.17.a
+		add_stability = -0.05
+	}
+}


### PR DESCRIPTION
They are stupid events and as far as I can tell it only is a problem for exactly one country now (down from two, when it used to make-or-break your France game), which is Romania. 