### PR TITLE
Pact of Steel QoL change

### DIFF
--- a/common/national_focus/italy.txt
+++ b/common/national_focus/italy.txt
@@ -10264,7 +10264,6 @@ focus_tree = {
 				tooltip = ITA_germ_italy_same_tt
 				ITA = { has_government = ROOT }
 			}
-			is_in_faction = no
 			is_subject = no
 			NOT = { has_country_flag = ENG_ditched_by_the_germans_flag }
 		}


### PR DESCRIPTION
Made it not require Germany and Italy *not* be in the same faction, since it doesn't auto-skip if you are in a faction together this is a superfluous check.