### PR TITLE
Made oil and aluminium spawn in a fixed state (NSW) for Australia

### DIFF
--- a/common/national_focus/australia.txt
+++ b/common/national_focus/australia.txt
@@ -1320,45 +1320,17 @@
 		available_if_capitulated = no
 		search_filters = { FOCUS_FILTER_INDUSTRY }
 
-		complete_tooltip = {
-			random_state = {
-				limit = { has_state_flag = AST_rationing_and_recycling_alu }
-				add_resource = {
-					type = aluminium
-					amount = 24
-				}
-			}
-			random_state = {
-				limit = { has_state_flag = AST_rationing_and_recycling_oil }
-				add_resource = {
-					type = oil
-					amount = 12
-				}
-			}
-		}
 
 		completion_reward = {
-			random_owned_controlled_state = {
-				limit = {
-					is_in_home_area = yes
-					NOT = { state = 674 }
-				}
+			285 = {
 				add_resource = {
 					type = aluminium
 					amount = 24
-				}
-				set_state_flag = AST_rationing_and_recycling_alu
-			}
-			random_owned_controlled_state = {
-				limit = {
-					is_in_home_area = yes
-					NOT = { state = 674 }
 				}
 				add_resource = {
 					type = oil
 					amount = 12
 				}
-				set_state_flag = AST_rationing_and_recycling_oil
 			}
 		}
 	}


### PR DESCRIPTION
Stops it being in a silly state, or PNG.