### PR TITLE
(Bugfix, minor QoL changes) Romania

### DIFF
--- a/common/decisions/ROM.txt
+++ b/common/decisions/ROM.txt
@@ -45,7 +45,7 @@ ROM_oil_production = {
 		}
 		available = {
 			has_tech = excavation4
-			num_of_civilian_factories_available_for_projects > 14
+			num_of_civilian_factories_available_for_projects > 11
 			owns_state = 76
 			controls_state = 76
 		}
@@ -63,10 +63,10 @@ ROM_oil_production = {
 		fire_only_once = yes
 
 		cost = 50
-		days_remove = 60
+		days_remove = 75
 
 		modifier = {
-			civilian_factory_use = 15
+			civilian_factory_use = 12
 		}
 
 		ai_will_do = {

--- a/common/ideas/romania.txt
+++ b/common/ideas/romania.txt
@@ -1134,13 +1134,13 @@ ideas = {
 					build_cost_ic = -0.15 instant = yes
 				}
 				armor = {
-					build_cost_ic = -0.1 instant = yes 
+					build_cost_ic = -0.10 instant = yes 
 				}
 				mechanized_equipment = {
-					build_cost_ic = -0.15 instant = yes 
+					build_cost_ic = -0.10 instant = yes 
 				}
 				motorized_equipment = {
-					build_cost_ic = -0.05 instant = yes 
+					build_cost_ic = -0.15 instant = yes 
 				}
 			}
 			

--- a/common/ideas/romania.txt
+++ b/common/ideas/romania.txt
@@ -1131,16 +1131,16 @@ ideas = {
 
 			equipment_bonus = {
 				infantry_equipment = {
-					build_cost_ic = -0.1 instant = yes
+					build_cost_ic = -0.05 instant = yes
 				}
 				armor = {
 					build_cost_ic = -0.1 instant = yes 
 				}
 				mechanized_equipment = {
-					build_cost_ic = -0.1 instant = yes 
+					build_cost_ic = -0.05 instant = yes 
 				}
 				motorized_equipment = {
-					build_cost_ic = -0.1 instant = yes 
+					build_cost_ic = -0.05 instant = yes 
 				}
 			}
 			

--- a/common/ideas/romania.txt
+++ b/common/ideas/romania.txt
@@ -1131,13 +1131,13 @@ ideas = {
 
 			equipment_bonus = {
 				infantry_equipment = {
-					build_cost_ic = -0.05 instant = yes
+					build_cost_ic = -0.15 instant = yes
 				}
 				armor = {
 					build_cost_ic = -0.1 instant = yes 
 				}
 				mechanized_equipment = {
-					build_cost_ic = -0.05 instant = yes 
+					build_cost_ic = -0.15 instant = yes 
 				}
 				motorized_equipment = {
 					build_cost_ic = -0.05 instant = yes 


### PR DESCRIPTION
Fixed Romania spirits so Grand Army doesn't downgrade Reserve Army spirit for infantry, motorized cost
Changed Derna Oilfield decision to 12 civs over 75 days, from 15 civs over 60 days. Same total civ usage, just to make it slightly easier for Romania to not build past the point where you can't click the button. 
My idea (which was overruled) was to just remove the check, so it consumes all your civs if you have less than 15 civs available for construction, but it is what it is.
